### PR TITLE
Change jupyter terminal to bash

### DIFF
--- a/pyspark-jupyter/Dockerfile
+++ b/pyspark-jupyter/Dockerfile
@@ -25,6 +25,9 @@ RUN set -eux; \
 RUN mkdir -p $SPARK_MASTER_LOG && \
   ln -sf /dev/stdout $SPARK_MASTER_LOG/spark-master.out
 
+COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
+RUN chown -R ${spark_uid}:${spark_uid} /etc/jupyter
+
 USER ${spark_uid}
 
 ENTRYPOINT ["/opt/jupyter-entrypoint.sh"]

--- a/pyspark-jupyter/Dockerfile
+++ b/pyspark-jupyter/Dockerfile
@@ -9,6 +9,10 @@ USER 0
 COPY jupyter-entrypoint.sh /opt/
 RUN chmod +x /opt/jupyter-entrypoint.sh
 
+ENV PYTHONPATH $PYTHONPATH:/opt/spark/python:/opt/spark/python/lib/py4j-0.10.9-src.zip
+ENV PYSPARK_PYTHON $PYENV_ROOT/shims/python3
+ENV PYSPARK_DRIVER_PYTHON $PYENV_ROOT/shims/python3
+
 ENV SPARK_MASTER_PORT 7077
 ENV SPARK_MASTER_WEBUI_PORT 8080
 ENV SPARK_MASTER_LOG /spark/logs

--- a/pyspark-jupyter/jupyter-entrypoint.sh
+++ b/pyspark-jupyter/jupyter-entrypoint.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-export PYTHONPATH=$PYTHONPATH:/opt/spark/python:/opt/spark/python/lib/py4j-0.10.9-src.zip
-export PYSPARK_PYTHON=${PYENV_ROOT}/shims/python3
-export PYSPARK_DRIVER_PYTHON=${PYENV_ROOT}/shims/python3
-
 WORKDIR=/home/spark/work
 mkdir -p ${WORKDIR}
 cd ${WORKDIR}
+
+jupyter lab --generate-config
+
+cat << EOF >> ${HOME}/.jupyter/jupyter_notebook_config.py
+c.NotebookApp.terminado_settings = { 'shell_command': ['/bin/bash'] }
+EOF
+
 if [[ ! -z "${JUPYTER_TOKEN}" ]]; then
-    tokenOpt="--NotebookApp.token='${JUPYTER_TOKEN}'"
+    echo "c.NotebookApp.token = ${JUPYTER_TOKEN}" >> ${HOME}/.jupyter/jupyter_notebook_config.py
 fi
-exec jupyter lab --ip=0.0.0.0 --no-browser $tokenOpt
+
+exec jupyter lab --ip=0.0.0.0 --no-browser

--- a/pyspark-jupyter/jupyter-entrypoint.sh
+++ b/pyspark-jupyter/jupyter-entrypoint.sh
@@ -4,14 +4,8 @@ WORKDIR=/home/spark/work
 mkdir -p ${WORKDIR}
 cd ${WORKDIR}
 
-jupyter lab --generate-config
-
-cat << EOF >> ${HOME}/.jupyter/jupyter_notebook_config.py
-c.NotebookApp.terminado_settings = { 'shell_command': ['/bin/bash'] }
-EOF
-
 if [[ ! -z "${JUPYTER_TOKEN}" ]]; then
-    echo "c.NotebookApp.token = ${JUPYTER_TOKEN}" >> ${HOME}/.jupyter/jupyter_notebook_config.py
+    echo "c.NotebookApp.token = ${JUPYTER_TOKEN}" >> /etc/jupyter/jupyter_notebook_config.py
 fi
 
-exec jupyter lab --ip=0.0.0.0 --no-browser
+exec jupyter lab

--- a/pyspark-jupyter/jupyter-entrypoint.sh
+++ b/pyspark-jupyter/jupyter-entrypoint.sh
@@ -5,7 +5,7 @@ mkdir -p ${WORKDIR}
 cd ${WORKDIR}
 
 if [[ ! -z "${JUPYTER_TOKEN}" ]]; then
-    echo "c.NotebookApp.token = ${JUPYTER_TOKEN}" >> /etc/jupyter/jupyter_notebook_config.py
+    echo "c.NotebookApp.token = '${JUPYTER_TOKEN}'" >> /etc/jupyter/jupyter_notebook_config.py
 fi
 
 exec jupyter lab

--- a/pyspark-jupyter/jupyter_notebook_config.py
+++ b/pyspark-jupyter/jupyter_notebook_config.py
@@ -2,4 +2,5 @@ c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 
+# Avoid to start terminal as login mode
 c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash']}

--- a/pyspark-jupyter/jupyter_notebook_config.py
+++ b/pyspark-jupyter/jupyter_notebook_config.py
@@ -1,0 +1,5 @@
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.port = 8888
+c.NotebookApp.open_browser = False
+
+c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash']}


### PR DESCRIPTION
## 課題

Jupyter LabのUIからTerminalを起動すると、dockerfileで指定したPATHが継承されず、PYTHONにパスが通ってないシェルが起動される

## 原因

以下の要因が重なって、PATHが上書きされるため

- Jupyterプロセスは端末接続なし (tty=?) で起動している。
- 端末接続なしでJupyterのUIからTerminalを起動すると、[loginモードで起動される](https://github.com/jupyter/notebook/blob/d8308e13803ba1c6e92f129381e615af6c6e00d3/notebook/terminal/__init__.py#L21-L34)。
- loginモードで起動されると/etc/profileを読み込む
- /etc/profileでは一般ユーザーだった場合、**現在設定しているPATHを無視して、デフォルトのPATHを上書きしている**。

## 解決策

Jupyterのconfigを生成し、Terminalをbashのインタラクティブモードで起動するよう設定する。